### PR TITLE
Update to redis4cats 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.14, 2.13.6, 3.0.0]
+        scala: [2.12.17, 2.13.10, 3.2.2]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,13 +50,13 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Setup Ruby
-        if: matrix.scala == '2.13.6'
+        if: matrix.scala == '2.13.10'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.1
 
       - name: Install microsite dependencies
-        if: matrix.scala == '2.13.6'
+        if: matrix.scala == '2.13.10'
         run: |
           gem install saas
           gem install jekyll -v 4.2.0
@@ -66,7 +66,7 @@ jobs:
 
       - run: sbt --client '++${{ matrix.scala }}; test; mimaReportBinaryIssues'
 
-      - if: matrix.scala == '2.13.6'
+      - if: matrix.scala == '2.13.10'
         run: sbt --client '++${{ matrix.scala }}; site/makeMicrosite'
 
   publish:
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6]
+        scala: [2.13.10]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
-val scala213 = "2.13.6"
+val scala213 = "2.13.10"
 
 ThisBuild / scalaVersion := scala213
-ThisBuild / crossScalaVersions := Seq("2.12.14", scala213, "3.0.0")
+ThisBuild / crossScalaVersions := Seq("2.12.17", scala213, "3.2.2")
 
 ThisBuild / licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
-val kindProjectorV = "0.13.0"
+val kindProjectorV = "0.13.2"
 val betterMonadicForV = "0.3.1"
 
 // Projects
@@ -43,7 +43,7 @@ lazy val site = project.in(file("site"))
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "io.chrisdavenport"           %% "epimetheus"                 % "0.5.0-M2",
-    "dev.profunktor"              %% "redis4cats-effects"         % "1.0.0"
+    "dev.profunktor"              %% "redis4cats-effects"         % "1.4.0"
   ),
   libraryDependencies ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) { case Some((2, _)) =>
     Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.3.1")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.2")
 addSbtPlugin("io.chrisdavenport" % "sbt-davenverse" % "0.1.4")


### PR DESCRIPTION
And bump also all other dependency versions, especially Scala itself.

The new redis4cats version brings as usual new operations that needed to be covered. As the transactions support became more fine-grained, not all of it can be fully supported, but the operations that worked before are still covered, so no regression in a narrower sense.